### PR TITLE
Fix spacing and minor FAQ corrections

### DIFF
--- a/about.html
+++ b/about.html
@@ -48,8 +48,7 @@
             
             <p class="lead">
                 Hat.sh is a Javascript app that provides secure file encryption using the <a
-                    href="https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">AES-256-GCM</a> algorithm from the <a href="
-                https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">WebCryptoAPI</a> included in your browser.
+                    href="https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">AES-256-GCM</a> algorithm from the <a href="https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">WebCryptoAPI</a> included in your browser.
                 <br><br>
                 It's <u>fast</u>, <u>secure</u> and runs <u>locally</u> - the app never uploads any files to the
                 server.

--- a/about.html
+++ b/about.html
@@ -50,10 +50,10 @@
                 Hat.sh is a Javascript app that provides secure file encryption using the <a
                     href="https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">AES-256-GCM</a> algorithm from the <a href="
                 https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">WebCryptoAPI</a> included in your browser.
-                <br>
+                <br><br>
                 It's <u>fast</u>, <u>secure</u> and runs <u>locally</u> - the app never uploads any files to the
                 server.
-                <br>
+                <br><br>
                 To encrypt a file, click <u>Browse</u>, select a file, <u>type</u> in a password or
                 <u>generate</u> one using the built-in password generator, and then press <u>Encrypt</u>. Within a few seconds, the encrypted file will be ready to download.
             </p>
@@ -122,15 +122,15 @@
                             href="https://ko-fi.com/shdvapps">donating</a> to support the project.</p>
                     <br>
                     <h5>How do I use Hat.sh?</h5>
-                        <p>1) Browse for a file, 2) enter a password or randomly generate a password, 3) click the 'Encrypt' or 'Decrypt' button, and 4) download the encrypted file.</p>
+                        <p>1) Browse for a file, 2) enter a password or randomly generate a password, 3) click the 'Encrypt' button, and 4) download the encrypted file.</p>
                         <br>
                         <h5>Which file types are supported? Is there a file size limit?</h5>
-                            <p>Hat.sh accept all file types. There's no file size limit, meaning files of any size can be encrypted.</p>
+                            <p>Hat.sh accepts all file types. There's no file size limit, meaning files of any size can be encrypted.</p>
                             <br>
                             <h5>Is Hat.sh secure?</h5>
                                 <p>Yes, the app encrypts files using the <a
                                         href="https://www.w3.org/TR/WebCryptoAPI/#aes-gcm">AES-GCM</a> algorithm
-                                    provided by the WebCryptoAPI.<br> Everything is done offline in your browser - no data
+                                    provided by the WebCryptoAPI. Everything is done offline in your browser - no data
                                     is sent to any server.</p>
                                 <br>
                                 <h5>I forgot my password, can I still decrypt my files?</h5>


### PR DESCRIPTION
I think the section at the top would look better with a space between each line, so I've just added some extra <br> tags. I've also corrected 'accept' to 'accepts' under 'Which file types are supported?' and corrected the 'How do I use Hat.sh?' and 'Is Hat.sh secure?'. 'How do I use Hat.sh?' is outlined twice on the About page; it might be worth getting rid of one of them - e.g. keeping the FAQ question and removing the bit at the top. Sorry for missing these things in the previous pull request.